### PR TITLE
Enhance Theme Customizer and Block Editor Integration

### DIFF
--- a/assets/css/editor.css
+++ b/assets/css/editor.css
@@ -1,4 +1,64 @@
-/* Editor styles */
-body {
-    font-family: "Inter", sans-serif;
+/* Editor Styles for DadeCore Theme */
+
+/*
+The primary purpose of this file is to ensure that the editor experience
+matches the front-end experience as closely as possible.
+
+Many global styles (colors, typography, layout widths) are automatically
+applied by WordPress based on theme.json settings. The CSS variables
+defined in inc/customizer.php (e.g., --dadecore-primary-color) are also
+made available to the editor.
+
+This file should be used for:
+1. Overriding or fine-tuning styles if the automatic application isn't perfect.
+2. Styling editor-specific wrapper elements if needed.
+3. Ensuring customizer-driven font choices are correctly applied if theme.json
+   defaults or block-specific styles override them too aggressively.
+*/
+
+/* Apply Customizer font choices to the main editor wrapper and headings.
+   This helps ensure that the base font settings from the Customizer are
+   respected, even if individual blocks or theme.json settings try to
+   override them at a global level within the editor. Using !important
+   can be necessary if theme.json styles are too specific. */
+.editor-styles-wrapper {
+    font-family: var(--dadecore-body-font-family);
+}
+
+.editor-styles-wrapper h1,
+.editor-styles-wrapper h2,
+.editor-styles-wrapper h3,
+.editor-styles-wrapper h4,
+.editor-styles-wrapper h5,
+.editor-styles-wrapper h6 {
+    font-family: var(--dadecore-heading-font-family);
+}
+
+/* Apply Customizer primary color to links within the editor */
+.editor-styles-wrapper a {
+    color: var(--dadecore-primary-color);
+}
+
+/*
+  It's generally recommended to let theme.json handle content widths
+  (contentSize, wideSize) as WordPress uses these to style the editor area.
+  If you need to override these specifically for the editor wrapper visuals:
+
+  .editor-styles-wrapper {
+    max-width: var(--wp--style--global--content-size); // Example using theme.json generated var
+    margin-left: auto;
+    margin-right: auto;
+  }
+*/
+
+/*
+  If you have specific CSS for elements that look different in the editor
+  than on the front-end, you can add those rules here. For example, if
+  a custom block needs slight adjustments to appear correctly in the editor.
+*/
+
+/* Example: Ensure blockquotes use the body font by default in editor,
+   unless a block style specifically changes it. */
+.editor-styles-wrapper blockquote {
+    font-family: var(--dadecore-body-font-family);
 }

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,8 +1,20 @@
 /* Main theme styles */
 body {
-    color: #333;
+    font-family: var(--dadecore-body-font-family);
+    color: #333; /* Default text color, can be overridden by theme.json or specific block styles */
 }
+
+h1, h2, h3, h4, h5, h6 {
+    font-family: var(--dadecore-heading-font-family);
+    /* Margin/padding for headings should be defined here or in a reset/typography partial if not handled by blocks */
+}
+
+a {
+    color: var(--dadecore-primary-color);
+}
+
 .site-header {
+    background-color: var(--dadecore-header-bg-color);
     padding: 1rem 0;
     position: sticky;
     top: 0;
@@ -28,6 +40,12 @@ body {
 }
 .footer-column {
     flex: 1;
+}
+
+.site-footer {
+    background-color: var(--dadecore-footer-bg-color);
+    padding: 2rem 0; /* Base padding for the footer */
+    color: #fff; /* Assuming footer text should be light on a dark background */
 }
 
 .content-with-sidebar {

--- a/functions.php
+++ b/functions.php
@@ -54,8 +54,20 @@ function dadecore_scripts() {
     wp_enqueue_style( 'dadecore-main', get_template_directory_uri() . '/assets/css/main.css', [], $theme_version );
 
     wp_enqueue_script( 'dadecore-main', get_template_directory_uri() . '/assets/js/main.js', [], $theme_version, true );
+
+    // Enqueue Google Fonts
+    wp_enqueue_style( 'dadecore-google-fonts', 'https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Poppins:wght@400;700&display=swap', [], null );
 }
 add_action( 'wp_enqueue_scripts', 'dadecore_scripts' );
+
+/**
+ * Enqueue styles for the block editor.
+ */
+function dadecore_editor_assets() {
+    // Enqueue Google Fonts for the editor
+    wp_enqueue_style( 'dadecore-google-fonts-editor', 'https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Poppins:wght@400;700&display=swap', [], null );
+}
+add_action( 'enqueue_block_editor_assets', 'dadecore_editor_assets' );
 
 /**
  * Register widget areas.

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -93,21 +93,28 @@ function dadecore_customize_register( $wp_customize ) {
 add_action( 'customize_register', 'dadecore_customize_register' );
 
 /**
- * Output custom styles based on Customizer settings.
+ * Output custom styles based on Customizer settings using CSS Custom Properties.
  */
 function dadecore_customizer_css() {
-    $primary     = get_theme_mod( 'dadecore_primary_color', '#2fd072' );
-    $header_bg   = get_theme_mod( 'dadecore_header_bg', '#0a2540' );
-    $footer_bg   = get_theme_mod( 'dadecore_footer_bg', '#0a2540' );
-    $body_font   = get_theme_mod( 'dadecore_body_font', 'Inter' );
-    $heading_font = get_theme_mod( 'dadecore_heading_font', 'Poppins' );
+    $primary_color     = get_theme_mod( 'dadecore_primary_color', '#2fd072' );
+    $header_bg_color   = get_theme_mod( 'dadecore_header_bg', '#0a2540' );
+    $footer_bg_color   = get_theme_mod( 'dadecore_footer_bg', '#0a2540' );
+    $body_font_family  = get_theme_mod( 'dadecore_body_font', 'Inter' );
+    $heading_font_family = get_theme_mod( 'dadecore_heading_font', 'Poppins' );
+
+    // Fallback for fonts in case the selected font is not available.
+    $body_font_stack = $body_font_family === 'Poppins' ? 'Poppins, sans-serif' : 'Inter, sans-serif';
+    $heading_font_stack = $heading_font_family === 'Inter' ? 'Inter, sans-serif' : 'Poppins, sans-serif';
+
     ?>
-    <style type="text/css">
-        body { font-family: '<?php echo esc_attr( $body_font ); ?>', sans-serif; }
-        h1, h2, h3, h4, h5, h6 { font-family: '<?php echo esc_attr( $heading_font ); ?>', sans-serif; }
-        a { color: <?php echo esc_attr( $primary ); ?>; }
-        .site-header { background-color: <?php echo esc_attr( $header_bg ); ?>; }
-        .site-footer { background-color: <?php echo esc_attr( $footer_bg ); ?>; }
+    <style type="text/css" id="dadecore-customizer-css">
+        :root {
+            --dadecore-primary-color: <?php echo esc_attr( $primary_color ); ?>;
+            --dadecore-header-bg-color: <?php echo esc_attr( $header_bg_color ); ?>;
+            --dadecore-footer-bg-color: <?php echo esc_attr( $footer_bg_color ); ?>;
+            --dadecore-body-font-family: '<?php echo esc_attr( $body_font_stack ); ?>';
+            --dadecore-heading-font-family: '<?php echo esc_attr( $heading_font_stack ); ?>';
+        }
     </style>
     <?php
 }


### PR DESCRIPTION
- Refactored Customizer CSS output to use CSS Custom Properties.
- Updated main.css to utilize these CSS Custom Properties for theme styling.
- Enqueued Google Fonts (Inter & Poppins) for both frontend and block editor.
- Rewrote editor.css to use theme CSS variables, improving WYSIWYG accuracy by reflecting Customizer font and color choices in the editor.
- Verified `the_content()` usage in templates for block rendering.
- Ensured `theme.json` and existing block editor supports are leveraged.

This provides a more consistent and modern customization experience, aligning front-end appearance with Customizer settings and improving the block editor's preview accuracy.